### PR TITLE
Add action to build and publish the PR for easier review

### DIFF
--- a/.github/workflows/build_and_publish.yaml
+++ b/.github/workflows/build_and_publish.yaml
@@ -1,0 +1,25 @@
+name: Testing the Blog Page publication
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  jekyll:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    # Use GitHub Actions' cache to shorten build times and decrease load on servers
+    - uses: actions/cache@v2
+      with:
+        path: vendor/bundle
+        key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile') }}
+        restore-keys: |
+          ${{ runner.os }}-gems-
+
+    # Build and Publish
+    - uses:  helaili/jekyll-action@v2
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build_and_publish.yaml
+++ b/.github/workflows/build_and_publish.yaml
@@ -23,3 +23,4 @@ jobs:
     - uses:  helaili/jekyll-action@v2
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
+        jekyll_src: .


### PR DESCRIPTION
Currently the reviewers need to pull the PR branch and run docker-compose up in order to visualize PR's blog posts. By using this action, the blog can be built and published in the environment tab.

After researching a bit more, GitHub does not support publishing a GitHub Page from multiple branches. Closing this for now.